### PR TITLE
Add resume export options and download support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,12 @@ import { Snippet, Section, SnippetBankSection } from './types';
 import { v4 as uuidv4 } from 'uuid';
 import { ToastContainer, toast } from 'react-toastify';
 import { improveSnippetWithAI, parseResumeWithAI } from './services/geminiService';
+import {
+  exportResumeToFile,
+  ResumeExportFormat,
+  getFormatLabel,
+  hasExportableContent,
+} from './services/exportService';
 
 const initialResumeState: Section[] = [
   {
@@ -291,6 +297,21 @@ const App: React.FC = () => {
     }));
   };
 
+  const handleExportResume = (format: ResumeExportFormat) => {
+    if (!hasExportableContent(resumeSections)) {
+      toast.warn('Add content to your resume before exporting.');
+      return;
+    }
+
+    try {
+      exportResumeToFile(resumeSections, format);
+      toast.success(`Resume exported as ${getFormatLabel(format)}.`);
+    } catch (error) {
+      console.error('Error exporting resume:', error);
+      toast.error('Failed to export resume.');
+    }
+  };
+
   return (
     <DndContext
       sensors={sensors}
@@ -316,6 +337,7 @@ const App: React.FC = () => {
             onUpdateSnippetContent={updateSnippetContent}
             onImproveSnippet={improveSnippet}
             activeDragId={activeDragId}
+            onExport={handleExportResume}
           />
         </main>
       </div>

--- a/components/ResumeEditor.tsx
+++ b/components/ResumeEditor.tsx
@@ -1,9 +1,14 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Section as SectionType } from '../types';
 import { Section } from './Section';
+import {
+  resumeExportFormats,
+  ResumeExportFormat,
+  hasExportableContent,
+} from '../services/exportService';
 
 interface ResumeEditorProps {
   sections: SectionType[];
@@ -14,6 +19,7 @@ interface ResumeEditorProps {
   onUpdateSnippetContent: (sectionId: string, snippetId: string, newContent: string) => void;
   onImproveSnippet: (sectionId: string, snippetId: string, content: string) => void;
   activeDragId: string | null;
+  onExport: (format: ResumeExportFormat) => void;
 }
 
 export const ResumeEditor: React.FC<ResumeEditorProps> = ({
@@ -25,6 +31,7 @@ export const ResumeEditor: React.FC<ResumeEditorProps> = ({
   onUpdateSnippetContent,
   onImproveSnippet,
   activeDragId,
+  onExport,
 }) => {
   const { setNodeRef } = useDroppable({
     id: 'resume-editor-droppable',
@@ -32,20 +39,65 @@ export const ResumeEditor: React.FC<ResumeEditorProps> = ({
 
   const sectionIds = sections.map(s => s.id);
   const isDraggingSection = activeDragId && activeDragId.startsWith('section-');
+  const [selectedFormat, setSelectedFormat] = useState<ResumeExportFormat>('md');
+  const canExport = hasExportableContent(sections);
+
+  const handleFormatChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedFormat(event.target.value as ResumeExportFormat);
+  };
+
+  const handleExportClick = () => {
+    onExport(selectedFormat);
+  };
 
   return (
     <div className="bg-white p-12 rounded-lg shadow-lg max-w-4xl mx-auto min-h-full">
-      <div className="flex justify-between items-center mb-10 border-b pb-6 border-slate-200">
+      <div className="flex flex-wrap justify-between items-center gap-4 mb-10 border-b pb-6 border-slate-200">
         <h2 className="text-3xl font-bold text-slate-800">Your Resume</h2>
-        <button
-          onClick={onAddSection}
-          className="bg-green-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-green-600 transition-colors flex items-center"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
-          </svg>
-          Add Section
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <label htmlFor="resume-export-format" className="text-sm font-medium text-slate-600">
+              Export as
+            </label>
+            <select
+              id="resume-export-format"
+              value={selectedFormat}
+              onChange={handleFormatChange}
+              className="border border-slate-300 rounded-lg py-2 px-3 text-sm text-slate-700 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {resumeExportFormats.map(option => (
+                <option key={option.value} value={option.value} title={option.description}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={handleExportClick}
+            disabled={!canExport}
+            className={`flex items-center font-semibold py-2 px-4 rounded-lg transition-colors ${
+              canExport
+                ? 'bg-blue-600 text-white hover:bg-blue-700'
+                : 'bg-slate-300 text-slate-500 cursor-not-allowed'
+            }`}
+            title={canExport ? undefined : 'Add content to your resume before exporting.'}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M3 3a2 2 0 012-2h10a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V3zm11 0H6v4h8V3zm-8 6a1 1 0 000 2h2v4a1 1 0 002 0v-4h2a1 1 0 100-2H6z" />
+            </svg>
+            Export Resume
+          </button>
+          <button
+            onClick={onAddSection}
+            className="bg-green-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-green-600 transition-colors flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Add Section
+          </button>
+        </div>
       </div>
       
       <div

--- a/services/exportService.ts
+++ b/services/exportService.ts
@@ -1,0 +1,193 @@
+import { Section } from '../types';
+
+export type ResumeExportFormat = 'md' | 'txt' | 'json' | 'html';
+
+export interface ResumeExportFormatOption {
+  value: ResumeExportFormat;
+  label: string;
+  description?: string;
+}
+
+interface NormalizedSection {
+  title: string;
+  items: string[];
+}
+
+interface FormatMetadata {
+  label: string;
+  extension: string;
+  mimeType: string;
+  description?: string;
+  serializer: (sections: NormalizedSection[]) => string;
+}
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const normalizeSections = (sections: Section[] = []): NormalizedSection[] =>
+  sections
+    .map(section => ({
+      title: section.title?.trim() ?? '',
+      items: (section.snippets ?? [])
+        .map(snippet => snippet.content?.trim() ?? '')
+        .filter(Boolean),
+    }))
+    .filter(section => section.title.length > 0 || section.items.length > 0);
+
+const formatConfig: Record<ResumeExportFormat, FormatMetadata> = {
+  md: {
+    label: 'Markdown (.md)',
+    extension: 'md',
+    mimeType: 'text/markdown',
+    description: 'Markdown formatted resume ready for Markdown editors.',
+    serializer: sections =>
+      sections
+        .map(({ title, items }) => {
+          const header = title ? `## ${title}` : '';
+          const bullets = items.map(item => `- ${item}`).join('\n');
+          return [header, bullets].filter(Boolean).join('\n\n');
+        })
+        .join('\n\n'),
+  },
+  txt: {
+    label: 'Plain text (.txt)',
+    extension: 'txt',
+    mimeType: 'text/plain',
+    description: 'Plain text version with headings and bullet points.',
+    serializer: sections =>
+      sections
+        .map(({ title, items }) => {
+          const header = title
+            ? `${title.toUpperCase()}\n${'-'.repeat(title.length)}`
+            : '';
+          const bullets = items.map(item => `• ${item}`).join('\n');
+          return [header, bullets].filter(Boolean).join('\n\n');
+        })
+        .join('\n\n'),
+  },
+  json: {
+    label: 'JSON (.json)',
+    extension: 'json',
+    mimeType: 'application/json',
+    description: 'Structured data for integrations or future editing.',
+    serializer: sections =>
+      JSON.stringify(
+        {
+          sections: sections.map(({ title, items }) => ({
+            title,
+            snippets: items,
+          })),
+        },
+        null,
+        2,
+      ),
+  },
+  html: {
+    label: 'HTML (.html)',
+    extension: 'html',
+    mimeType: 'text/html',
+    description: 'Styled HTML document ready for printing or conversion.',
+    serializer: sections => {
+      const renderedSections = sections
+        .map(({ title, items }) => {
+          const sectionParts: string[] = [];
+          if (title) {
+            sectionParts.push(`<h2>${escapeHtml(title)}</h2>`);
+          }
+          if (items.length > 0) {
+            const listItems = items
+              .map(item => `<li>${escapeHtml(item)}</li>`)
+              .join('\n');
+            sectionParts.push(`<ul>\n${listItems}\n</ul>`);
+          }
+          return `<section>\n${sectionParts.join('\n')}\n</section>`;
+        })
+        .join('\n\n');
+
+      return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    body { font-family: Arial, sans-serif; color: #1f2937; line-height: 1.5; margin: 2rem auto; max-width: 800px; }
+    h1 { text-align: center; font-size: 2rem; margin-bottom: 2rem; color: #0f172a; }
+    section { margin-bottom: 1.5rem; }
+    h2 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    ul { list-style: disc; margin-left: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Resume</h1>
+  ${renderedSections}
+</body>
+</html>`;
+    },
+  },
+};
+
+const ensureFormatConfig = (format: ResumeExportFormat): FormatMetadata => {
+  const config = formatConfig[format];
+  if (!config) {
+    throw new Error(`Unsupported resume export format: ${format}`);
+  }
+  return config;
+};
+
+export const resumeExportFormats: ResumeExportFormatOption[] = Object.entries(formatConfig).map(
+  ([value, config]) => ({
+    value: value as ResumeExportFormat,
+    label: config.label,
+    description: config.description,
+  }),
+);
+
+export const hasExportableContent = (sections: Section[]): boolean =>
+  normalizeSections(sections).length > 0;
+
+export const generateResumeContent = (
+  sections: Section[],
+  format: ResumeExportFormat,
+): string => {
+  const config = ensureFormatConfig(format);
+  const normalizedSections = normalizeSections(sections);
+
+  if (normalizedSections.length === 0) {
+    throw new Error('No resume content to export');
+  }
+
+  return config.serializer(normalizedSections);
+};
+
+export const exportResumeToFile = (
+  sections: Section[],
+  format: ResumeExportFormat,
+  filename = 'resume',
+): void => {
+  const config = ensureFormatConfig(format);
+  const content = generateResumeContent(sections, format);
+  const blob = new Blob([content], { type: config.mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = `${filename}.${config.extension}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+export const getFormatLabel = (format: ResumeExportFormat): string =>
+  ensureFormatConfig(format).label;
+
+export const getFormatExtension = (format: ResumeExportFormat): string =>
+  ensureFormatConfig(format).extension;
+
+export const getFormatMimeType = (format: ResumeExportFormat): string =>
+  ensureFormatConfig(format).mimeType;


### PR DESCRIPTION
## Summary
- add a reusable export service that normalizes resume sections and formats Markdown, text, JSON, and HTML downloads
- expose export controls in the resume editor so users can choose a format and trigger the download
- wire the app to validate content before exporting and notify the user about export success or failure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99deca47883318bc22d951d5511b6

## Summary by Sourcery

Add export functionality to generate and download resumes in multiple formats with UI controls and user notifications

New Features:
- Implement exportService to normalize resume sections and serialize them into Markdown, plain text, JSON, or HTML files
- Add format selector dropdown and export button in ResumeEditor, disabled until there is exportable content
- Integrate export handler in App to validate resume content and display toast notifications on export success or failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export your resume to Markdown, Plain Text, JSON, or HTML.
  * Choose the desired format via a new dropdown in the editor header.
  * One-click “Export Resume” button initiates a download with the correct file type.
  * Clear notifications indicate success or failure during export.
  * Export is intelligently disabled when there’s no content to export.
  * Existing editing actions (like adding sections) remain available alongside the new export controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->